### PR TITLE
DM-48139: Avoid multi-paragraph footnotes

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -445,7 +445,6 @@ This will be enforced by the service frontend.
 .. [#] The result of a sync request with multiple stencils and an alternate image type could instead be a collection (such as a ZIP file) holding multiple images.
        However, this would mean the output MIME type of a sync request would depend on the number of stencil parameters, which is ugly.
        It would also introduce a new requirement for generating output collections that are not Butler collections.
-
        It is unlikely there will be a compelling need for a sync request for multiple cutouts with image conversion.
        That use case can use an async request instead.
 


### PR DESCRIPTION
Multi-paragraph footnotes are formatted extremely oddly, so avoid them.